### PR TITLE
PLATAPP-527: Updating Notifications.Sdk.Preview to v0.1.664 + Added DisplayName to Notifications CTOR

### DIFF
--- a/sdk/Finbourne.Notifications.Sdk.Extensions.IntegrationTests/ApiExceptionExtensionsTest.cs
+++ b/sdk/Finbourne.Notifications.Sdk.Extensions.IntegrationTests/ApiExceptionExtensionsTest.cs
@@ -132,8 +132,8 @@ namespace Finbourne.Notifications.Sdk.Extensions.IntegrationTests
         {
             try
             {
-                var testScope = new string('a', 100);
-                var testCode = new string('b', 100);
+                var testScope = new string('a', 101);
+                var testCode = new string('b', 101);
                 var _ = _factory.Api<NotificationsApi>().CreateEmailNotification(testScope, testCode, _emailNotification);
             }
             catch (ApiException e)
@@ -145,11 +145,11 @@ namespace Finbourne.Notifications.Sdk.Extensions.IntegrationTests
                 {
                     //Should identify that there was a validation error with the code
                     Assert.That(errorResponse.Errors, Contains.Key("code"));
-                    Assert.That(errorResponse.Errors["code"].Single(), Is.EqualTo("Values for the field code must be non-zero in length and have no more than 64 characters. For more information please consult the documentation."));
+                    Assert.That(errorResponse.Errors["code"].Single(), Is.EqualTo("Values for the field code must be non-zero in length and have no more than 100 characters. For more information please consult the documentation."));
 
                     //Should identify that there was a validation error with the scope
                     Assert.That(errorResponse.Errors, Contains.Key("scope"));
-                    Assert.That(errorResponse.Errors["scope"].Single(), Is.EqualTo("Values for the field scope must be non-zero in length and have no more than 64 characters. For more information please consult the documentation."));
+                    Assert.That(errorResponse.Errors["scope"].Single(), Is.EqualTo("Values for the field scope must be non-zero in length and have no more than 100 characters. For more information please consult the documentation."));
 
                     Assert.That(errorResponse.Detail, Does.Match("One or more elements of the request were invalid.*"));
                     Assert.That(errorResponse.Name, Is.EqualTo("InvalidRequestFailure"));

--- a/sdk/Finbourne.Notifications.Sdk.Extensions.IntegrationTests/Finbourne.Notifications.Sdk.Extensions.IntegrationTests.csproj
+++ b/sdk/Finbourne.Notifications.Sdk.Extensions.IntegrationTests/Finbourne.Notifications.Sdk.Extensions.IntegrationTests.csproj
@@ -11,7 +11,7 @@
     <RepositoryType>git</RepositoryType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Finbourne.Notifications.Sdk.Preview" Version="0.1.616" />
+    <PackageReference Include="Finbourne.Notifications.Sdk.Preview" Version="0.1.664" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />

--- a/sdk/Finbourne.Notifications.Sdk.Extensions.IntegrationTests/PollyApiRetryHandlerTest.cs
+++ b/sdk/Finbourne.Notifications.Sdk.Extensions.IntegrationTests/PollyApiRetryHandlerTest.cs
@@ -27,6 +27,7 @@ namespace Finbourne.Notifications.Sdk.Extensions.IntegrationTests
 
         private readonly Notification _mockResponse = new Notification("id",
             "description",
+            "displayName",
             "deliveryChannel",
             new Dictionary<string, object>() { { "receipient", null } },
             new Dictionary<string, object>() { { "content", null } },

--- a/sdk/Finbourne.Notifications.Sdk.Extensions.Tests/Finbourne.Notifications.Sdk.Extensions.Tests.csproj
+++ b/sdk/Finbourne.Notifications.Sdk.Extensions.Tests/Finbourne.Notifications.Sdk.Extensions.Tests.csproj
@@ -12,7 +12,7 @@
     <RepositoryType>git</RepositoryType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Finbourne.Notifications.Sdk.Preview" Version="0.1.616" />
+    <PackageReference Include="Finbourne.Notifications.Sdk.Preview" Version="0.1.664" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />

--- a/sdk/Finbourne.Notifications.Sdk.Extensions/Finbourne.Notifications.Sdk.Extensions.csproj
+++ b/sdk/Finbourne.Notifications.Sdk.Extensions/Finbourne.Notifications.Sdk.Extensions.csproj
@@ -16,7 +16,7 @@
     <None Include="../../LICENSE.md" Pack="true" PackagePath="LICENSE.md" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Finbourne.Notifications.Sdk.Preview" Version="0.1.616" />
+    <PackageReference Include="Finbourne.Notifications.Sdk.Preview" Version="0.1.664" />
     <PackageReference Include="JsonSubTypes" Version="1.8.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />


### PR DESCRIPTION
# Pull Request Checklist

- [x] Read the [contributing guidelines](../blob/master/docs/CONTRIBUTING.md)
- [ ] Tests pass

# Description of the PR

As of Notifications `v0.1.618`, the `Notification` DTO takes a display name in its CTOR. In this MR, I have upgraded `Finbourne.Notifications.Sdk.Preview` to the latest version `0.1.664`, then added a dummy `displayName` in `PollyApiRetryHandlerTests`.
